### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ cookiecutter https://github.com/asif-mahmud/pyramid_runner.git
 
 The `Makefile` inside the `project folder` provides some easy shortcut commands-
 
-- `make setup` : This command must be run once at the beginnng.
+- `make setup` : This command must be run once at the beginning.
 - `make revision`: Make a database revision by [Alembic](http://alembic.zzzcomputing.com/).
 - `make upgrade` : Migrate your database to latest revision.
 - `make downgrade` : Migrate your database to a previous revision.
@@ -147,7 +147,7 @@ A subclass of `BaseJSONResponse`. This is helpful to quickly define
 a status(error or success) report standard for the API.
 
 ### `security.base.BaseUserRetriever`
-A base class to retreive authenticated user info from request params.
+A base class to retrieve authenticated user info from request params.
 
 **NOTE:** Removed from version 3.9+ 
 

--- a/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/views/base.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.project_name}}/views/base.py
@@ -98,7 +98,7 @@ class BaseStatusReport(BaseJSONResponse):
     This class basically sets the foure attributes -
     `code`, `status`, `msg`, `error` from class level
     attributes `__code__`, `__status__`, `__msg__` and
-    `__error__` respectedly. It may be useful to define
+    `__error__` respectively. It may be useful to define
     some status report standards for the API.
 
     Aside from that, this can be used just like the


### PR DESCRIPTION
There are small typos in:
- README.md
- {{cookiecutter.project_name}}/{{cookiecutter.project_name}}/views/base.py

Fixes:
- Should read `retrieve` rather than `retreive`.
- Should read `respectively` rather than `respectedly`.
- Should read `beginning` rather than `beginnng`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md